### PR TITLE
Fix token header and workflow inputs

### DIFF
--- a/.github/workflows/avd-deploy.yml
+++ b/.github/workflows/avd-deploy.yml
@@ -12,6 +12,20 @@ on:
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+    inputs:
+      resource_group_name:
+        description: 'Nombre del Resource Group'
+        required: true
+      host_pool_name:
+        description: 'Nombre del Host Pool'
+        required: true
+      total_users:
+        description: 'Número total de usuarios concurrentes'
+        required: false
+        default: '2'
+      user_upns:
+        description: 'UPNs o Grupos AAD (separados por comas)'
+        required: false
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -28,6 +42,13 @@ jobs:
       # Runs a single command using the runners shell
       - name: Run a one-line script
         run: echo Hello, world!
+
+      - name: Show received inputs
+        run: |
+          echo "Resource group: ${{ github.event.inputs.resource_group_name }}"
+          echo "Host pool: ${{ github.event.inputs.host_pool_name }}"
+          echo "Total users: ${{ github.event.inputs.total_users }}"
+          echo "User UPNs: ${{ github.event.inputs.user_upns }}"
 
       # Runs a set of commands using the runners shell
       - name: Run a multi-line script

--- a/index.html
+++ b/index.html
@@ -66,9 +66,10 @@
           {
             method: 'POST',
             headers: {
-              'Accept': 'application/vnd.github.v3+json',
+              'Accept': 'application/vnd.github+json',
+              'X-GitHub-Api-Version': '2022-11-28',
               'Content-Type': 'application/json',
-              'Authorization': 'Bearer ' + GITHUB_TOKEN
+              'Authorization': 'token ' + GITHUB_TOKEN
             },
             body: JSON.stringify({ ref, inputs })
           }


### PR DESCRIPTION
## Summary
- update GitHub API headers in index.html
- allow workflow to receive inputs via `workflow_dispatch`
- print the inputs during the job

## Testing
- `terraform fmt -check infra/*.tf` *(fails: terraform not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840173857b0832fbd88e5de8fc048d1